### PR TITLE
chore(release): 1.0.0-alpha.5 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.5](https://github.com/bjerkio/oidc-react/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-04-21)
+
+
+### Bug Fixes
+
+* Autosignin on expired user ([d5dce04](https://github.com/bjerkio/oidc-react/commit/d5dce04f51bdfcff49ab622f60875aedfe17fdb5))
+* Fix withAuth export ([4e0e2e1](https://github.com/bjerkio/oidc-react/commit/4e0e2e11675eda83fc543779d53f51f2ff96284e))
+
 # [1.0.0-alpha.4](https://github.com/bjerkio/oidc-react/compare/v1.0.0-alpha.3...v1.0.0-alpha.4) (2020-04-16)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-react",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "private": false,
   "description": "",
   "main": "build/src/index.js",


### PR DESCRIPTION
# [1.0.0-alpha.5](https://github.com/bjerkio/oidc-react/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-04-21)

### Bug Fixes

* Autosignin on expired user ([d5dce04](https://github.com/bjerkio/oidc-react/commit/d5dce04f51bdfcff49ab622f60875aedfe17fdb5))
* Fix withAuth export ([4e0e2e1](https://github.com/bjerkio/oidc-react/commit/4e0e2e11675eda83fc543779d53f51f2ff96284e))