### PR TITLE
feat: Add client secret & re-export oidc-client types

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -6,7 +6,7 @@ import {
   AuthContextProps,
 } from './AuthContextInterface';
 
-export const AuthContext = React.createContext<AuthContextProps|null>(null);
+export const AuthContext = React.createContext<AuthContextProps | null>(null);
 
 /**
  * @private
@@ -34,10 +34,18 @@ export const hasCodeInUrl = (location: Location): boolean => {
  */
 export const initUserManager = (props: AuthProviderProps): UserManager => {
   if (props.userManager) return props.userManager;
-  const { authority, clientId, redirectUri, responseType, scope } = props;
+  const {
+    authority,
+    clientId,
+    clientSecret,
+    redirectUri,
+    responseType,
+    scope,
+  } = props;
   return new UserManager({
     authority,
     client_id: clientId,
+    client_secret: clientSecret,
     redirect_uri: redirectUri,
     silent_redirect_uri: redirectUri,
     post_logout_redirect_uri: redirectUri,

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -37,6 +37,10 @@ export interface AuthProviderProps {
    */
   clientId?: string;
   /**
+   * Client secret defined on the identity server
+   */
+  clientSecret?: string;
+  /**
    * The redirect URI of your client application to receive a response from the OIDC/OAuth2 provider.
    */
   redirectUri?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
-export * from './AuthContext';
 export * from './useAuth';
 export * from './withAuth';
+export * from './AuthContext';
+
+export { User, UserManager } from 'oidc-client';


### PR DESCRIPTION
Hello,

This PR adds support for the `client_secret` parameter, which is super important. This PR also re-exports some oidc-client types that oidc-react events use as parameters.