### PR TITLE
fix: this._signinStart is not a function

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -105,7 +105,7 @@ export const AuthProvider: FC<AuthProviderProps> = ({
   return (
     <AuthContext.Provider
       value={{
-        signIn: async (args: any): Promise<void> => {
+        signIn: async (args: unknown): Promise<void> => {
           await userManager.signinRedirect(args);
         },
         signOut: async (): Promise<void> => {


### PR DESCRIPTION
Fixes an issue where its not possible to use signIn function

fix #173