### PR TITLE
feat: Add a pass-through option for UserManager's automaticSilentRenew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ typings/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+package-lock.json

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -41,6 +41,7 @@ export const initUserManager = (props: AuthProviderProps): UserManager => {
     redirectUri,
     responseType,
     scope,
+    automaticSilentRenew,
   } = props;
   return new UserManager({
     authority,
@@ -52,6 +53,7 @@ export const initUserManager = (props: AuthProviderProps): UserManager => {
     response_type: responseType || 'code',
     scope: scope || 'openid',
     loadUserInfo: true,
+    automaticSilentRenew,
   });
 };
 

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -62,6 +62,12 @@ export interface AuthProviderProps {
    * defaults to true
    */
   autoSignIn?: boolean;
+  /**
+   * Flag to indicate if there should be an automatic attempt to renew the access token prior to its expiration.
+   *
+   * defaults to false
+   */
+  automaticSilentRenew?: boolean;
 
   /**
    * On before sign in hook. Can be use to store the current url for use after signing in.


### PR DESCRIPTION
The `UserManager` supports `automaticSilentRenew`. The `UserManager` created in oidc-react already has everything else necessary, so I figured I'd add this as a setting to this library instead of fully creating my own `UserManager` just for this setting.

At the moment, oidc-react doesn't do anything to alert or avoid an access token from expiring out from under the user. This is happening in the project I'm working on - users keep the browser tab open long enough that the access token is expiring, which results in them just getting unauthorized requests from our services.

The underlying oidc-client library has several ways to deal with this scenario, notably it has the `automaticSilentRenew` option which will attempt to renew the access token as its about to expire.

All that is missing from oidc-react to enable this is the option being passed through. It defaults to `false` at the oidc-client level.

https://github.com/IdentityModel/oidc-client-js/wiki#other-optional-settings

I also put package-lock.json into the git ignore file, since the project uses yarn. This will keep that file out of pull requests. I can remove that from the PR if you want.

I also added note of the setting to the documentation.