### PR TITLE
feat: Make oidc-react compatible with Next.js and SSR

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -67,9 +67,11 @@ export const AuthProvider: FC<AuthProviderProps> = ({
   onBeforeSignIn,
   onSignIn,
   onSignOut,
-  location = window.location,
+  location = window && window.location,
   ...props
 }) => {
+  if (!location && typeof window === 'undefined') return <>{children}</>;
+
   const [userData, setUserData] = useState<User | null>(null);
 
   const userManager = initUserManager(props);


### PR DESCRIPTION
This PR aims to make the library compatible with Next.js and server-side rendering, where the `window` object is not available. Basically, if you don't provide a location of your own to `AuthProvider` and window is undefined, AuthProvider will return its children without doing anything. In Next.js, you will instead get authenticated on the subsequent client-side hydration.

fixes #340
fixes #329