### PR TITLE
fix: Load new state from session/local storage when available after a silent renew

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -114,7 +114,7 @@ export const AuthProvider: FC<AuthProviderProps> = ({
     userManager.events.addUserLoaded(updateUserData);
 
     return () => userManager.events.removeUserLoaded(updateUserData);
-  }, [userManager])
+  }, [])
 
   return (
     <AuthContext.Provider

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -104,6 +104,18 @@ export const AuthProvider: FC<AuthProviderProps> = ({
     getUser();
   }, [location]);
 
+  useEffect(() => {
+    // for refreshing react state when new state is available in e.g. session storage
+    const updateUserData = async () => {
+      const user = await userManager.getUser();
+      setUserData(user);
+    }
+
+    userManager.events.addUserLoaded(updateUserData);
+
+    return () => userManager.events.removeUserLoaded(updateUserData);
+  }, [userManager])
+
   return (
     <AuthContext.Provider
       value={{

--- a/src/__tests__/AuthContext.test.tsx
+++ b/src/__tests__/AuthContext.test.tsx
@@ -7,12 +7,18 @@ import { render, act, waitFor } from '@testing-library/react';
 
 jest.mock('oidc-client');
 
+const events = {
+  addUserLoaded: () => undefined,
+  removeUserLoaded: () => undefined,
+}
+
 describe('AuthContext', () => {
   it('should check for user and redirect', async () => {
     await act(async () => {
       const u = {
         getUser: jest.fn(),
         signinRedirect: jest.fn(),
+        events,
       } as any;
       const onBeforeSignIn = jest.fn();
       render(<AuthProvider userManager={u} onBeforeSignIn={onBeforeSignIn} />);
@@ -27,6 +33,7 @@ describe('AuthContext', () => {
       const u = {
         getUser: jest.fn(),
         signinRedirect: jest.fn(),
+        events,
       } as any;
       render(
         <AuthProvider userManager={u} autoSignIn={false}>
@@ -46,6 +53,7 @@ describe('AuthContext', () => {
     await act(async () => {
       const u = {
         getUser: jest.fn(),
+        events,
       } as any;
       render(<AuthProvider userManager={u} autoSignIn={false}></AuthProvider>);
       await waitFor(() => expect(u.getUser).toHaveBeenCalled());
@@ -69,6 +77,7 @@ describe('AuthContext', () => {
           access_token: 'token',
         }),
         signinCallback: jest.fn(),
+        events,
       } as any;
       const { getByText } = render(
         <AuthProvider userManager={userManager}>
@@ -91,6 +100,7 @@ describe('AuthContext', () => {
     const userManager = {
       getUser: jest.fn(),
       signinCallback: jest.fn(),
+      events,
     } as any;
     const location = {
       search: '?code=test-code',
@@ -116,6 +126,7 @@ describe('AuthContext', () => {
         access_token: 'token',
       }),
       removeUser: jest.fn(),
+      events,
     } as any;
     const onSignOut = jest.fn();
     render(
@@ -141,6 +152,7 @@ describe('AuthContext', () => {
         access_token: 'token',
       }),
       signoutRedirect: jest.fn(),
+      events,
     } as any;
     const onSignOut = jest.fn();
     render(
@@ -166,6 +178,7 @@ describe('AuthContext', () => {
         access_token: 'token',
       }),
       signoutRedirect: jest.fn(),
+      events,
     } as any;
     const onSignOut = jest.fn();
     render(

--- a/src/__tests__/AuthContext.test.tsx
+++ b/src/__tests__/AuthContext.test.tsx
@@ -5,12 +5,22 @@ import { UserManager } from 'oidc-client';
 import { AuthProvider, AuthContext } from '../AuthContext';
 import { render, act, waitFor } from '@testing-library/react';
 
-jest.mock('oidc-client');
-
 const events = {
   addUserLoaded: () => undefined,
   removeUserLoaded: () => undefined,
 }
+
+jest.mock('oidc-client', () => {
+  return {
+    UserManager: jest.fn().mockImplementation(() => {
+      return {
+        getUser: jest.fn(),
+        signinRedirect: jest.fn(),
+        events,
+      };
+    }),
+  };
+});
 
 describe('AuthContext', () => {
   it('should check for user and redirect', async () => {


### PR DESCRIPTION
Fixes https://github.com/bjerkio/oidc-react/issues/361

...I think. When I edited directly in node_modules (it complained when i npm linked because of duplicate react) it worked but this code is slightly different.