### PR TITLE
fix: Including 'Log' in export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export * from './withAuth';
 export * from './AuthContext';
 export * from './AuthContextInterface';
 
-export { User, UserManager } from 'oidc-client';
+export { User, UserManager, Log } from 'oidc-client';


### PR DESCRIPTION
Pretty straight forward. oidc-client exports `Log` which can be used for debugging. I've included that now in the oidc-react exports.