### PR TITLE
docs: fix incorrect import in HOC example

### DIFF
--- a/guides/WITHAUTH.md
+++ b/guides/WITHAUTH.md
@@ -7,7 +7,7 @@ OIDC React comes with a HOC withAuth! withAuth is a great way, much better then 
 withAuth returns a component wrapped in [authContext](../docs/interfaces/authcontextprops.md). Let's look at an example of use.
 
 ```typescript
-import { useAuth } from 'oidc-react';
+import { withAuth } from 'oidc-react';
 
 class Hello extends React.PureComponent<{}, {}> {
   render( = () => {


### PR DESCRIPTION
The example snippet for HOC usage was importing the `useAuth` function rather than `withAuth` in the markdown documentation.