### PR TITLE
fix: Remove `getUser` in callback handler

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -85,8 +85,7 @@ export const AuthProvider: FC<AuthProviderProps> = ({
        * Check if the user is returning back from OIDC.
        */
       if (hasCodeInUrl(location)) {
-        await userManager.signinCallback();
-        const user = await userManager.getUser();
+        const user = await userManager.signinCallback();
         setUserData(user);
         onSignIn && onSignIn(user);
         return;


### PR DESCRIPTION
Update to the signincallback flow to make state returned from oidc-client available to the onSignIn event

fixes #447 