### PR TITLE
feat: upgrade to oidc-client 1.11.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "faker": "^5.0.0",
     "jest": "^25.3.0",
     "jest-cli": "^26.0.1",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "ts-jest": "^25.3.1",
     "ts-node-dev": "^1.0.0-pre.40",
     "typedoc": "^0.20.5",
     "typedoc-plugin-markdown": "^3.0.3",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
     "typescript": "^3.5.3"
   },
   "jest": {
@@ -75,6 +75,6 @@
     "react-dom": "^17.0.0"
   },
   "dependencies": {
-    "oidc-client": "^1.9.1"
+    "oidc-client": "^1.11.5"
   }
 }

--- a/src/__tests__/AuthContext.test.tsx
+++ b/src/__tests__/AuthContext.test.tsx
@@ -153,6 +153,33 @@ describe('AuthContext', () => {
     });
   });
 
+  it('should refresh userData when new data is available', async () => {
+    const userManager = {
+      getUser: async () => ({
+        access_token: 'token',
+      }),
+      signinCallback: jest.fn(),
+      events: {
+        addUserLoaded: (fn: () => void) => fn(),
+        removeUserLoaded: () => undefined,
+      },
+    } as any;
+    const { getByText } = render(
+      <AuthProvider userManager={userManager}>
+        <AuthContext.Consumer>
+          {(value) =>
+            value?.userData && (
+              <span>Received: {value.userData.access_token}</span>
+            )
+          }
+        </AuthContext.Consumer>
+      </AuthProvider>,
+    );
+    await waitFor(() => {
+      expect(getByText(/^Received:/).textContent).toBe('Received: token');
+    });
+  });
+
   it('should login the user', async () => {
     const userManager = {
       getUser: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4493,7 +4493,7 @@ object.values@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-oidc-client@^1.9.1:
+oidc-client@^1.11.5:
   version "1.11.5"
   resolved "https://registry.yarnpkg.com/oidc-client/-/oidc-client-1.11.5.tgz#020aa193d68a3e1f87a24fcbf50073b738de92bb"
   integrity sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==


### PR DESCRIPTION
This upgrades the oidc-client package from 1.9.1 -> 1.11.5. It includes some good fixes, including a Firefox bug where silent renews were not working due to iframe's being `display: none` and then being ignored. I am not sure if the version was fixed at 1.9.1 for a specific reason, but I think it's a good and reasonably safe upgrade to do.

I also included a new test to chip away at https://github.com/bjerkio/oidc-react/issues/523.