### PR TITLE
chore: Allow react 16.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
   },
   "homepage": "https://github.com/bjerkio/oidc-react#readme",
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "dependencies": {
     "oidc-client": "^1.11.5"


### PR DESCRIPTION
similar to:
https://github.com/mui-org/material-ui/blob/bd79e8f8c5b8c77bc5c13d076377a18d2ceedfa2/packages/material-ui/package.json#L43

No need to force users to update react to version 17.0.x, its working fine for me with 16.8.x!