### PR TITLE
refactor: Move `UserManager` to state

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -80,8 +80,7 @@ export const AuthProvider: FC<AuthProviderProps> = ({
   ...props
 }) => {
   const [userData, setUserData] = useState<User | null>(null);
-
-  const userManager = initUserManager(props);
+  const [userManager] = useState<UserManager>(initUserManager(props));
 
   const signOutHooks = async (): Promise<void> => {
     setUserData(null);
@@ -123,7 +122,7 @@ export const AuthProvider: FC<AuthProviderProps> = ({
       return;
     };
     getUser();
-  }, [location]);
+  }, [location, userManager, autoSignIn, onBeforeSignIn, onSignIn]);
 
   useEffect(() => {
     // for refreshing react state when new state is available in e.g. session storage
@@ -135,7 +134,7 @@ export const AuthProvider: FC<AuthProviderProps> = ({
     userManager.events.addUserLoaded(updateUserData);
 
     return () => userManager.events.removeUserLoaded(updateUserData);
-  }, []);
+  }, [userManager]);
 
   return (
     <AuthContext.Provider

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -137,7 +137,7 @@ export interface AuthContextProps {
   /**
    * See [UserManager](https://github.com/IdentityModel/oidc-client-js/wiki#usermanager) for more details.
    */
-  userManager: UserManager | null;
+  userManager: UserManager;
   /**
    * See [User](https://github.com/IdentityModel/oidc-client-js/wiki#user) for more details.
    */


### PR DESCRIPTION
userManager must be in a state as well

- Fixes react-hooks/exhaustive-deps warnings
- userManager can not be null -> fixes definition