### PR TITLE
support event addUserLoaded

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -126,15 +126,15 @@ export const AuthProvider: FC<AuthProviderProps> = ({
   }, [location]);
 
   useEffect(() => {
-    // for refreshing react state when new state is available in e.g. session storage
-    const updateUserData = async () => {
+    // for userManager event UserLoaded (e.g. initial load, silent renew)
+    const handleUserLoaded = async () => {
       const user = await userManager.getUser();
       isMountedRef.current && setUserData(user);
     };
 
-    userManager.events.addUserLoaded(updateUserData);
+    userManager.events.addUserLoaded(handleUserLoaded);
 
-    return () => userManager.events.removeUserLoaded(updateUserData);
+    return () => userManager.events.removeUserLoaded(handleUserLoaded);
   }, []);
 
   useEffect(() => {

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -137,6 +137,17 @@ export const AuthProvider: FC<AuthProviderProps> = ({
     return () => userManager.events.removeUserLoaded(updateUserData);
   }, []);
 
+  useEffect(() => {
+    // for userManager event UserUnloaded (e.g. removeUser)
+    const handleUserUnloaded = () => {
+      isMountedRef.current && setUserData(null);
+    };
+
+    userManager.events.addUserUnloaded(handleUserUnloaded);
+
+    return () => userManager.events.removeUserUnloaded(handleUserUnloaded);
+  }, [userManager]);
+  
   return (
     <AuthContext.Provider
       value={{

--- a/src/__tests__/AuthContext.test.tsx
+++ b/src/__tests__/AuthContext.test.tsx
@@ -8,6 +8,8 @@ import { render, act, waitFor } from '@testing-library/react';
 const events = {
   addUserLoaded: () => undefined,
   removeUserLoaded: () => undefined,
+  addUserUnloaded: () => undefined,
+  removeUserUnloaded: () => undefined,
 }
 
 jest.mock('oidc-client', () => {

--- a/src/__tests__/AuthContext.test.tsx
+++ b/src/__tests__/AuthContext.test.tsx
@@ -187,8 +187,8 @@ describe('AuthContext', () => {
       }),
       signinCallback: jest.fn(),
       events: {
+        ...events,
         addUserLoaded: (fn: () => void) => fn(),
-        removeUserLoaded: () => undefined,
       },
     } as any;
     const { getByText } = render(


### PR DESCRIPTION
- depends on #579 merge request (for effect depends `[userManager]`....)

This event is useful to listen to when the application calls userManager.removeUser.
