### PR TITLE
feat: Add metadata parameter for providers missing proper CORS headers.

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -48,9 +48,11 @@ export const initUserManager = (props: AuthProviderProps): UserManager => {
     popupWindowFeatures,
     popupRedirectUri,
     popupWindowTarget,
+    metadata,
   } = props;
   return new UserManager({
     authority,
+    metadata: metadata,
     client_id: clientId,
     client_secret: clientSecret,
     redirect_uri: redirectUri,

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -1,4 +1,4 @@
-import { UserManager, User } from 'oidc-client';
+import { UserManager, User, OidcMetadata } from 'oidc-client';
 export interface Location {
   search: string;
   hash: string;
@@ -32,6 +32,10 @@ export interface AuthProviderProps {
    * The URL of the OIDC/OAuth2 provider.
    */
   authority?: string;
+  /**
+   * Manually set metadata if CORS is not configured on the OIDC/OAuth2 provider.
+   */
+  metadata?: OidcMetadata;
   /**
    * Your client application's identifier as registered with the OIDC/OAuth2 provider.
    */


### PR DESCRIPTION
Adding the metadata as an optional parameter to account for providers who have not set the proper CORS headers on their discovery endpoint.

