### PR TITLE
feat: add extraQueryParams to AuthProvider

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -48,6 +48,7 @@ export const initUserManager = (props: AuthProviderProps): UserManager => {
     popupWindowFeatures,
     popupRedirectUri,
     popupWindowTarget,
+    extraQueryParams
   } = props;
   return new UserManager({
     authority: authority || '',
@@ -63,6 +64,7 @@ export const initUserManager = (props: AuthProviderProps): UserManager => {
     popup_redirect_uri: popupRedirectUri,
     popupWindowTarget: popupWindowTarget,
     automaticSilentRenew,
+    extraQueryParams
   });
 };
 

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -33,6 +33,10 @@ export interface AuthProviderProps {
    */
   authority?: string;
   /**
+   * Extra query params passed to the authorization url.
+   */
+  extraQueryParams?: Record<string, string>
+  /**
    * Your client application's identifier as registered with the OIDC/OAuth2 provider.
    */
   clientId?: string;


### PR DESCRIPTION
The package `oidc-client-ts` offers a way to pass extra query params to the authorization endpoint.

Documentation: [https://authts.github.io/oidc-client-ts/classes/OidcClientSettingsStore.html#extraQueryParams](url)