### PR TITLE
feat: add `onSignInError` to AuthProvider

### DIFF
--- a/docs/interfaces/authcontextinterface.authproviderprops.md
+++ b/docs/interfaces/authcontextinterface.authproviderprops.md
@@ -150,6 +150,24 @@ Defined in: [src/AuthContextInterface.ts:112](https://github.com/pamapa/oidc-rea
 
 ___
 
+### onSignInError
+
+• `Optional` **onSignInError**: (error) => *void*
+
+On Sign In Error. Can be use to handle errors when sign in fails.
+
+#### Type declaration:
+
+▸ (error): *void*
+
+**Returns:** *void*
+
+Defined in: [src/AuthContextInterface.ts:125](https://github.com/pamapa/oidc-react/blob/5ae1406/src/AuthContextInterface.ts#L125)
+
+Defined in: [src/AuthContextInterface.ts:125](https://github.com/pamapa/oidc-react/blob/5ae1406/src/AuthContextInterface.ts#L125)
+
+___
+
 ### onSignOut
 
 • `Optional` **onSignOut**: (`options?`: [*AuthProviderSignOutProps*](authcontextinterface.authprovidersignoutprops.md)) => *void* \| *Promise*<void\>

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -79,6 +79,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
   onSignIn,
   onSignOut,
   location = window.location,
+  onSignInError,
   ...props
 }) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -113,7 +114,11 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
        * Check if the user is returning back from OIDC.
        */
       if (hasCodeInUrl(location)) {
-        const user: any = await userManager.signinCallback();
+        const user: any = await userManager.signinCallback().catch(error => {
+          if (onSignInError) {
+            onSignInError(error)
+          }
+        });
         setUserData(user);
         setIsLoading(false);
         onSignIn && onSignIn(user);
@@ -131,7 +136,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
       return;
     };
     getUser();
-  }, [location, userManager, autoSignIn, onBeforeSignIn, onSignIn]);
+  }, [location, userManager, autoSignIn, onBeforeSignIn, onSignIn, onSignInError]);
 
   useEffect(() => {
     // for refreshing react state when new state is available in e.g. session storage

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -118,6 +118,11 @@ export interface AuthProviderProps {
    * On sign out hook. Can be a async function.
    */
   onSignOut?: (options?: AuthProviderSignOutProps) => Promise<void> | void;
+
+  /**
+   * On sign in error. Can be a async function.
+   */
+  onSignInError?: (error: Error) => void;
 }
 
 export interface AuthContextProps {


### PR DESCRIPTION
This new error callback let us have a better control (for giving feedback to the users) when the `onSignIn` function fails