### PR TITLE
fix: avoid reinitiating partial authentication flow when user is already authenticated 

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -123,11 +123,11 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     (async () => {
       // Store current isMounted since this could change while awaiting async operations below
       const isMounted = isMountedRef.current;
-
+      const user = await userManager!.getUser();
       /**
        * Check if the user is returning back from OIDC.
        */
-      if (hasCodeInUrl(location)) {
+      if (!user && hasCodeInUrl(location)) {
         const user = (await userManager.signinCallback()) || null;
         setUserData(user);
         setIsLoading(false);
@@ -135,7 +135,6 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
         return;
       }
 
-      const user = await userManager!.getUser();
       if ((!user || user.expired) && autoSignIn) {
         const state = onBeforeSignIn ? onBeforeSignIn() : undefined;
         userManager.signinRedirect({ state });

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -12,6 +12,7 @@ import {
   User,
   SigninRedirectArgs,
   SignoutRedirectArgs,
+  UserLoadedCallback,
 } from 'oidc-client-ts';
 import {
   Location,
@@ -145,18 +146,17 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     })();
   }, [location, userManager, autoSignIn, onBeforeSignIn, onSignIn]);
 
+  /**
+   * Registers a UserLoadedCallback to update the userData state on a userLoaded event 
+   */
   useEffect(() => {
-    // for refreshing react state when new state is available in e.g. session storage
-    const updateUserData = async () => {
-      const user = await userManager.getUser();
+    const updateUserData: UserLoadedCallback = (user: User): void => {
       isMountedRef.current && setUserData(user);
     };
-
     userManager.events.addUserLoaded(updateUserData);
-
     return () => userManager.events.removeUserLoaded(updateUserData);
   }, [userManager]);
-
+  
   const value = useMemo<AuthContextProps>(() => {
     return {
       signIn: async (args?: SigninRedirectArgs): Promise<void> => {

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -147,7 +147,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
   }, [location, userManager, autoSignIn, onBeforeSignIn, onSignIn]);
 
   /**
-   * Registers a UserLoadedCallback to update the userData state on a userLoaded event 
+   * Registers a UserLoadedCallback to update the userData state on a userLoaded event
    */
   useEffect(() => {
     const updateUserData: UserLoadedCallback = (user: User): void => {
@@ -156,7 +156,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     userManager.events.addUserLoaded(updateUserData);
     return () => userManager.events.removeUserLoaded(updateUserData);
   }, [userManager]);
-  
+
   const value = useMemo<AuthContextProps>(() => {
     return {
       signIn: async (args?: SigninRedirectArgs): Promise<void> => {


### PR DESCRIPTION
Fixes: #922, and possibly some others. Influenced by authts/oidc-client-ts#402.

[TLDR](https://github.com/authts/oidc-client-ts/issues/402#issuecomment-1056999675):  

> The problem here is that the stored state is removed immediately after the redirection from login. So if the user presses "back", then logs again, there is no more state available, even tho the redirect URL contains a state parameter. In other words, oidc-client-ts tries to load the stored state, but none is available because it removed it the first time the user logged in.

Personally what I discovered was that upon redirect from login, we still had the auth params in our query string. So if one were to reload the page or browse forward a page then hit the back button, we'd encounter the same thing. [hasCodeInUrl() would pass which would trigger an invalid auth flow again](https://github.com/bjerkio/oidc-react/blob/3eaf620c06ebd3c13aa7932ea3e00c981b3ac325/src/AuthContext.tsx#L130-L131). Therefore, I simply add a check that not only does `hasCodeInUrl` check out, but also that userManager doesn't actively have a user already authenticated. 

I feel like I might be missing something here since I'm not very aware of all the possible authentication flows that are being used with oidc-react. If I could get some additional eyes on this I'd greatly appreciate it. 