### PR TITLE
fix: handle token refresh failure

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -115,7 +115,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     onSignIn && onSignIn(userFromPopup);
     await userManager.signinPopupCallback();
   }, [userManager, onSignIn]);
-  
+
   useEffect(() => {
     isMountedRef.current = true;
     (async () => {
@@ -141,7 +141,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     })();
     return () => {
       isMountedRef.current = false;
-    }
+    };
   }, [location, userManager, autoSignIn, onBeforeSignIn, onSignIn]);
 
   /**
@@ -151,8 +151,10 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     const updateUserData: UserLoadedCallback = (user: User): void => {
       setUserData(user);
     };
-    const onSilentRenewError: SilentRenewErrorCallback = async (error: Error): Promise<void> => {
-      if(autoSignOut) {
+    const onSilentRenewError: SilentRenewErrorCallback = async (
+      error: Error,
+    ): Promise<void> => {
+      if (autoSignOut) {
         await signOutHooks();
         await userManager.signoutRedirect(autoSignOutArgs);
       }
@@ -162,7 +164,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     return () => {
       userManager.events.removeUserLoaded(updateUserData);
       userManager.events.removeSilentRenewError(onSilentRenewError);
-    }
+    };
   }, [userManager]);
 
   const value = useMemo<AuthContextProps>(() => {

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -91,6 +91,7 @@ export const initUserManager = (props: AuthProviderProps): UserManager => {
 export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
   children,
   autoSignIn = true,
+  autoSignInArgs,
   onBeforeSignIn,
   onSignIn,
   onSignOut,
@@ -113,7 +114,6 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     onSignIn && onSignIn(userFromPopup);
     await userManager.signinPopupCallback();
   }, [userManager, onSignIn]);
-
   
   useEffect(() => {
     isMountedRef.current = true;
@@ -132,7 +132,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
 
       if ((!user || user.expired) && autoSignIn) {
         const state = onBeforeSignIn ? onBeforeSignIn() : undefined;
-        userManager.signinRedirect({ state });
+        await userManager.signinRedirect({ ...autoSignInArgs, state });
       } else if (isMountedRef.current) {
         setUserData(user);
         setIsLoading(false);

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -77,8 +77,8 @@ export interface AuthProviderProps {
    */
   location?: Location;
   /**
-   * Flag to control automatic redirection to the OIDC/OAuth2 provider when not signed in. 
-   * 
+   * Flag to control automatic redirection to the OIDC/OAuth2 provider when not signed in.
+   *
    * Defaults to true.
    */
   autoSignIn?: boolean;
@@ -87,8 +87,8 @@ export interface AuthProviderProps {
    */
   autoSignInArgs?: SigninRedirectArgs;
   /**
-   * Flag to control automatic sign out redirection to the OIDC/OAuth2 provider when silent renewal fails. 
-   * 
+   * Flag to control automatic sign out redirection to the OIDC/OAuth2 provider when silent renewal fails.
+   *
    * Defaults to true.
    */
   autoSignOut?: boolean;
@@ -112,7 +112,8 @@ export interface AuthProviderProps {
    *  The features parameter to window.open for the popup signin window
    *
    * defaults to 'location=no,toolbar=no,width=500,height=500,left=100,top=100'
-   */  popupWindowFeatures?: PopupWindowFeatures;
+   */
+  popupWindowFeatures?: PopupWindowFeatures;
   /**
    *  The URL for the page containing the call to signinPopupCallback to handle the callback from the OIDC/OAuth2
    *

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -87,6 +87,16 @@ export interface AuthProviderProps {
    */
   autoSignInArgs?: SigninRedirectArgs;
   /**
+   * Flag to control automatic sign out redirection to the OIDC/OAuth2 provider when silent renewal fails. 
+   * 
+   * Defaults to true.
+   */
+  autoSignOut?: boolean;
+  /**
+   * Optional sign out arguments to be used when `autoSignOut` is enabled.
+   */
+  autoSignOutArgs?: SignoutRedirectArgs;
+  /**
    * Flag to indicate if there should be an automatic attempt to renew the access token prior to its expiration.
    *
    * Defaults to true.
@@ -95,7 +105,7 @@ export interface AuthProviderProps {
   /**
    *  Flag to control if additional identity data is loaded from the user info endpoint in order to populate the user's profile.
    *
-   * defaults to true
+   * Defaults to true.
    */
   loadUserInfo?: boolean;
   /**

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -77,9 +77,15 @@ export interface AuthProviderProps {
    */
   location?: Location;
   /**
-   * defaults to true
+   * Flag to control automatic redirection to the OIDC/OAuth2 provider when not signed in. 
+   * 
+   * Defaults to true.
    */
   autoSignIn?: boolean;
+  /**
+   * Optional sign in arguments to be used when `autoSignIn` is enabled.
+   */
+  autoSignInArgs?: SigninRedirectArgs;
   /**
    * Flag to indicate if there should be an automatic attempt to renew the access token prior to its expiration.
    *
@@ -103,16 +109,14 @@ export interface AuthProviderProps {
    */
   popupRedirectUri?: string;
   /**
-   *  The target parameter to window.open for the popup signin window.
-   *
+   *  The target parameter to window.open for the popup signin window.   *
    * defaults to '_blank'
    */
   popupWindowTarget?: string;
   /**
    * On before sign in hook. Can be use to store the current url for use after signing in.
    *
-   * This only gets called if autoSignIn is true
-   */
+   * This only gets called if autoSignIn is true   */
   onBeforeSignIn?: () => string;
   /**
    * On sign out hook. Can be a async function.

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -83,7 +83,7 @@ export interface AuthProviderProps {
   /**
    * Flag to indicate if there should be an automatic attempt to renew the access token prior to its expiration.
    *
-   * defaults to false
+   * Defaults to true.
    */
   automaticSilentRenew?: boolean;
   /**
@@ -96,8 +96,7 @@ export interface AuthProviderProps {
    *  The features parameter to window.open for the popup signin window
    *
    * defaults to 'location=no,toolbar=no,width=500,height=500,left=100,top=100'
-   */
-  popupWindowFeatures?: PopupWindowFeatures;
+   */  popupWindowFeatures?: PopupWindowFeatures;
   /**
    *  The URL for the page containing the call to signinPopupCallback to handle the callback from the OIDC/OAuth2
    *

--- a/src/__tests__/AuthContext.test.tsx
+++ b/src/__tests__/AuthContext.test.tsx
@@ -1,13 +1,15 @@
 /* eslint @typescript-eslint/no-explicit-any: 0 */
 /* eslint @typescript-eslint/explicit-function-return-type: 0 */
 import React from 'react';
-import { UserManager } from 'oidc-client-ts';
+import {SilentRenewErrorCallback, UserManager} from 'oidc-client-ts';
 import { AuthProvider, AuthContext } from '../AuthContext';
-import { render, act, waitFor } from '@testing-library/react';
+import {render, act, waitFor, RenderResult} from '@testing-library/react';
 
 const events = {
   addUserLoaded: () => undefined,
   removeUserLoaded: () => undefined,
+  addSilentRenewError: () => undefined,
+  removeSilentRenewError: () => undefined,
 };
 
 jest.mock('oidc-client-ts', () => {
@@ -192,10 +194,8 @@ describe('AuthContext', () => {
         access_token: 'token',
       }),
       signinCallback: jest.fn(),
-      events: {
-        addUserLoaded: (fn: () => void) => fn(),
-        removeUserLoaded: () => undefined,
-      },
+      signoutRedirect: jest.fn(),
+      events,
     } as any;
     const { getByText } = render(
       <AuthProvider userManager={userManager}>
@@ -320,5 +320,51 @@ describe('AuthContext', () => {
         state: 'thebranches',
       }),
     );
+  });
+
+  it('should sign out redirect on silent renew failure', async () => {
+    // given: a signed in UserManager that stashes silentRenewError callbacks
+    const callbacks: SilentRenewErrorCallback[] = [];
+    const u = {
+      getUser: async () => ({
+        access_token: 'token',
+      }),
+      signinCallback: jest.fn(),
+      signoutRedirect: jest.fn(),
+      events: {
+        ...events,
+        addSilentRenewError: jest.fn(callback => callbacks.push(callback)),
+        removeSilentRenewError: jest.fn(callback => callbacks.splice(callbacks.indexOf(callback), 1))
+      }
+    } as any;
+
+    // when: the AuthProvider is mounted
+    let result: RenderResult;
+    await act(async() => {
+      result = render(
+        <AuthProvider userManager={u} />,
+      );
+    });
+
+    // then: the silentRenewError callback should be registered
+    expect(u.events.addSilentRenewError).toHaveBeenCalledTimes(1);
+    expect(callbacks).toHaveLength(1);
+
+    // when: the registered silentRenewError callback is called
+    await act(async() => {
+      callbacks[0](new Error('test'));
+    })
+
+    // then: the callback should trigger a signout redirect
+    expect(u.signoutRedirect).toHaveBeenCalledTimes(1);
+
+    // when: the AuthProvider is unmounted
+    act(() => {
+      result.unmount();
+    });
+
+    // then: the callback should be unregistered
+    expect(u.events.removeSilentRenewError).toHaveBeenCalledTimes(1);
+    expect(callbacks).toHaveLength(0);
   });
 });

--- a/src/__tests__/AuthContext.test.tsx
+++ b/src/__tests__/AuthContext.test.tsx
@@ -1,9 +1,9 @@
 /* eslint @typescript-eslint/no-explicit-any: 0 */
 /* eslint @typescript-eslint/explicit-function-return-type: 0 */
 import React from 'react';
-import {SilentRenewErrorCallback, UserManager} from 'oidc-client-ts';
+import { SilentRenewErrorCallback, UserManager } from 'oidc-client-ts';
 import { AuthProvider, AuthContext } from '../AuthContext';
-import {render, act, waitFor, RenderResult} from '@testing-library/react';
+import { render, act, waitFor, RenderResult } from '@testing-library/react';
 
 const events = {
   addUserLoaded: () => undefined,
@@ -333,17 +333,17 @@ describe('AuthContext', () => {
       signoutRedirect: jest.fn(),
       events: {
         ...events,
-        addSilentRenewError: jest.fn(callback => callbacks.push(callback)),
-        removeSilentRenewError: jest.fn(callback => callbacks.splice(callbacks.indexOf(callback), 1))
-      }
+        addSilentRenewError: jest.fn((callback) => callbacks.push(callback)),
+        removeSilentRenewError: jest.fn((callback) =>
+          callbacks.splice(callbacks.indexOf(callback), 1),
+        ),
+      },
     } as any;
 
     // when: the AuthProvider is mounted
     let result: RenderResult;
-    await act(async() => {
-      result = render(
-        <AuthProvider userManager={u} />,
-      );
+    await act(async () => {
+      result = render(<AuthProvider userManager={u} />);
     });
 
     // then: the silentRenewError callback should be registered
@@ -351,9 +351,9 @@ describe('AuthContext', () => {
     expect(callbacks).toHaveLength(1);
 
     // when: the registered silentRenewError callback is called
-    await act(async() => {
+    await act(async () => {
       callbacks[0](new Error('test'));
-    })
+    });
 
     // then: the callback should trigger a signout redirect
     expect(u.signoutRedirect).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Fixes #965 
Fixes #966

Adds a callback handler to trigger a signoutRedirect in the event that token renewal fails. This can happen for instance if an active user puts their computer to sleep, and then returns long after the token has expired. `oidc-client-ts` attempts to renew the token and fails. This would cause the app to still appear to be logged in, but API requests that required authentication would fail. 