### PR TITLE
chore: reset 3.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,6 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.0.4](https://github.com/bjerkio/oidc-react/compare/v3.0.3...v3.0.4) (2023-03-21)
-
-
-### Bug Fixes
-
-* isLoading has correct status when autoSignIn is disabled and user is signed out ([#982](https://github.com/bjerkio/oidc-react/issues/982)) ([db28cdd](https://github.com/bjerkio/oidc-react/commit/db28cdd6a6368d8d07f01f1827d77afd18d70bf1))
-
 ## [3.0.3](https://github.com/bjerkio/oidc-react/compare/v3.0.2...v3.0.3) (2023-03-16)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-react",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "private": false,
   "description": "",
   "repository": "github:bjerkio/oidc-react",


### PR DESCRIPTION
This should retrigger the generation of a 3.0.4 release PR, so long as the 3.0.4 release/tag have been deleted in GitHub. 