### PR TITLE
Add `metadata` parameter to AuthContext

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -65,6 +65,7 @@ export const initUserManager = (props: AuthProviderProps): UserManager => {
     popupRedirectUri,
     popupWindowTarget,
     extraQueryParams,
+    metadata,
   } = props;
   return new UserManager({
     authority: authority || '',
@@ -81,6 +82,7 @@ export const initUserManager = (props: AuthProviderProps): UserManager => {
     popupWindowTarget: popupWindowTarget,
     automaticSilentRenew,
     extraQueryParams,
+    metadata: metadata,
   });
 };
 

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -4,6 +4,7 @@ import {
   PopupWindowFeatures,
   SigninRedirectArgs,
   SignoutRedirectArgs,
+  OidcMetadata,
 } from 'oidc-client-ts';
 export interface Location {
   search: string;
@@ -38,6 +39,10 @@ export interface AuthProviderProps {
    * The URL of the OIDC/OAuth2 provider.
    */
   authority?: string;
+  /**
+   * Manually set metadata if CORS is not configured on the OIDC/OAuth2 provider.
+   */
+  metadata?: Partial<OidcMetadata>;
   /**
    * Extra query params passed to the authorization url.
    */


### PR DESCRIPTION
Useful  for providers missing proper CORS headers.

Continuation of <https://github.com/bjerkio/oidc-react/pull/715#issuecomment-1514691686>

Note:
I've tried running `generate-docs` but was unsuccessful:

```
yarn run v1.22.19
$ typedoc --gitRevision main --out docs src
[info] Loaded plugin typedoc-plugin-markdown
TypeDoc exiting with unexpected error:
TypeError: page.template is not a function
    at MarkdownTheme.render (D:\dev\work\temp\oidc-react\node_modules\typedoc-plugin-markdown\dist\theme.js:39:49)
    at Renderer.renderDocument (D:\dev\work\temp\oidc-react\node_modules\typedoc\dist\lib\output\renderer.js:183:40)
    at D:\dev\work\temp\oidc-react\node_modules\typedoc\dist\lib\output\renderer.js:159:22
    at Array.forEach (<anonymous>)
    at Renderer.render (D:\dev\work\temp\oidc-react\node_modules\typedoc\dist\lib\output\renderer.js:157:25)
    at async Application.generateDocs (D:\dev\work\temp\oidc-react\node_modules\typedoc\dist\lib\application.js:300:9)
    at async run (D:\dev\work\temp\oidc-react\node_modules\typedoc\dist\lib\cli.js:110:13)
error Command failed with exit code 6.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```