### PR TITLE
docs: improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ $ npm install oidc-react
 
 ## Usage
 
-```typescript
-...
+```tsx
 import { AuthProvider } from 'oidc-react';
 
 const oidcConfig = {

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Apart from this README, you can find details and examples of using the SDK in th
 
 - [SDK Documentation](docs/README.md)
 - [Guides](guides/)
-- [Example repository](https://github.com/simenandre/example-react-oidc)
+- [Example repository](https://github.com/simenandre/example-oidc-react)
 - [oidc-client-ts Documentation](https://authts.github.io/oidc-client-ts/)
 
 ## Contribute & Disclaimer

--- a/guides/HOOKS.md
+++ b/guides/HOOKS.md
@@ -6,7 +6,7 @@ OIDC React comes with hooks! Hooks are a great way, much better then using our [
 
 useAuth returns the same as our [authContext](../docs/interfaces/authcontextprops.md). Let's look at an example of use.
 
-```typescript
+```tsx
 import { useAuth } from 'oidc-react';
 
 export default () => {

--- a/guides/QUICKSTART.md
+++ b/guides/QUICKSTART.md
@@ -12,7 +12,7 @@ AuthProvider is a [Context](https://reactjs.org/docs/context.html) and holds mos
 
 Let's look at an example component.
 
-```typescript
+```tsx
 import { AuthProvider } from 'oidc-react';
 
 export default () => (
@@ -37,7 +37,7 @@ However, if we want the user to be sent to our dashboard when authenticated, we 
 
 Let's look at another example for that!
 
-```typescript
+```tsx
 import { AuthProvider } from 'oidc-react';
 
 export default App = () => (

--- a/guides/WITHAUTH.md
+++ b/guides/WITHAUTH.md
@@ -6,17 +6,16 @@ OIDC React comes with a HOC withAuth! withAuth is a great way, much better then 
 
 withAuth returns a component wrapped in [authContext](../docs/interfaces/authcontextprops.md). Let's look at an example of use.
 
-```typescript
+```tsx
 import { withAuth } from 'oidc-react';
 
 class Hello extends React.PureComponent<{}, {}> {
-  render( = () => {
+  render() {
     return (
       <p>Hello {this.props.authData.profile.name}!</p>
     );
   }
 }
-
 
 export default withAuth(Hello);
 ```


### PR DESCRIPTION
This fixes documentation link to the examples repository. React examples language hint "tsx" improves formatting because the examples are not pure TypeScript.