### PR TITLE
fix: multiplied code exchange requests in strict mode

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -122,11 +122,14 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
    * Handles user auth flow on initial render.
    */
   useEffect(() => {
+    let isMounted = true;
     isMountedRef.current = true;
     setIsLoading(true);
     (async () => {
       const user = await userManager!.getUser();
-      if (!user || user.expired) {
+      // isMountedRef cannot be used here as its value is updated by next useEffect.
+      // We intend to keep context of current useEffect.
+      if (isMounted && (!user || user.expired)) {
         // If the user is returning back from the OIDC provider, get and set the user data.
         if (hasCodeInUrl(location)) {
           const user = (await userManager.signinCallback()) || null;
@@ -146,6 +149,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
       setIsLoading(false);
     })();
     return () => {
+      isMounted = false;
       isMountedRef.current = false;
     };
   }, [location, userManager, autoSignIn, onBeforeSignIn, onSignIn]);


### PR DESCRIPTION
In current implementation with:

* React: 18.2.0 **strict mode**
* Identity Provider: IdentityServer4
* Flow: authorization code + pkce

We experience multiplied authorization code exchange requests as a result of not handling simulation of component immediate unmounting and remounting in strict mode.
![error-short](https://github.com/bjerkio/oidc-react/assets/57632531/34944354-330c-4e35-8d53-03e75d71bacb)

`isMountedRef` cannot be used as it will be updated during next useEffect:
![order](https://github.com/bjerkio/oidc-react/assets/57632531/9b06ac5d-2f1c-4c82-a4b5-7f2fdfc6b314)
![order-console](https://github.com/bjerkio/oidc-react/assets/57632531/900c8cab-cc37-4f4b-97c7-2755ea4f8463)

### Fix: local guard variable is introduced:

![fixed](https://github.com/bjerkio/oidc-react/assets/57632531/95c8e244-531d-41b3-b3f1-9c924867daad)


