### PR TITLE
chore: change return type of onBeforeSignIn

### DIFF
--- a/docs/interfaces/AuthProviderProps.md
+++ b/docs/interfaces/AuthProviderProps.md
@@ -187,11 +187,11 @@ ___
 
 ### onBeforeSignIn
 
-• `Optional` **onBeforeSignIn**: () => `string`
+• `Optional` **onBeforeSignIn**: () => `unknown`
 
 #### Type declaration
 
-▸ (): `string`
+▸ (): `unknown`
 
 On before sign in hook. Can be use to store the current url for use after signing in.
 
@@ -199,7 +199,7 @@ This only gets called if autoSignIn is true
 
 ##### Returns
 
-`string`
+`unknown`
 
 #### Defined in
 

--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -133,7 +133,7 @@ export interface AuthProviderProps {
    * On before sign in hook. Can be use to store the current url for use after signing in.
    *
    * This only gets called if autoSignIn is true   */
-  onBeforeSignIn?: () => string;
+  onBeforeSignIn?: () => unknown;
   /**
    * On sign out hook. Can be a async function.
    * @param userData User


### PR DESCRIPTION
Change return type of `onBeforeSignIn` from `string` to `unknown` in order to match `oidc-client-ts` type of `state` property.
See details in the issue https://github.com/bjerkio/oidc-react/issues/1020