### PR TITLE
fix: CVE-2023-46233 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bundlewatch": "bundlewatch --config .bundlewatch.config.json"
   },
   "dependencies": {
-    "oidc-client-ts": "2.2.4"
+    "oidc-client-ts": "2.4.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "5.16.5",


### PR DESCRIPTION
There is a vulnerability with crypto-js which is used in the oidc-client-ts. Crypto-js version is bumped in oidc-client-ts, but it seems dependabot didn't catch it here. 

https://security.snyk.io/package/npm/crypto-js

This is the PR on oidc-client-ts:
https://github.com/authts/oidc-client-ts/pull/1221

CVE issue
https://www.cve.org/CVERecord?id=CVE-2023-46233