### PR TITLE
feat: add `onSignInError` to AuthProvider

### DIFF
--- a/src/AuthContextInterface.ts
+++ b/src/AuthContextInterface.ts
@@ -143,6 +143,11 @@ export interface AuthProviderProps {
    * On sign out hook. Can be a async function.
    */
   onSignOut?: (options?: AuthProviderSignOutProps) => Promise<void> | void;
+
+  /**
+   * On sign in error. Can be a async function.
+   */
+  onSignInError?: (error: Error) => void;
 }
 
 export interface AuthContextProps {


### PR DESCRIPTION
This new error callback let us have a better control (for giving feedback to the users) when the `signIn` function fails
