### PR TITLE
fix: Call onSignIn when using hash params

### DIFF
--- a/src/__tests__/auth-context.test.tsx
+++ b/src/__tests__/auth-context.test.tsx
@@ -223,7 +223,7 @@ describe('AuthContext', () => {
     });
   });
 
-  it('should login the user', async () => {
+  it('should login the user with query params', async () => {
     const userManager = {
       getUser: vi.fn(),
       signinCallback: vi.fn(() => true),
@@ -233,6 +233,30 @@ describe('AuthContext', () => {
     const location = {
       search: '?code=login-test-code',
       hash: '',
+    };
+
+    const onSignIn = vi.fn();
+    render(
+      <AuthProvider
+        onSignIn={onSignIn}
+        userManager={userManager}
+        location={location}
+      />,
+    );
+    await waitFor(() => expect(onSignIn).toHaveBeenCalled());
+    await waitFor(() => expect(userManager.signinCallback).toHaveBeenCalled());
+  });
+
+  it('should login the user with hash params', async () => {
+    const userManager = {
+      getUser: vi.fn(),
+      signinCallback: vi.fn(() => true),
+      events,
+    } as any;
+
+    const location = {
+      search: '',
+      hash: '#code=login-test-code',
     };
 
     const onSignIn = vi.fn();

--- a/src/auth-context.tsx
+++ b/src/auth-context.tsx
@@ -35,11 +35,11 @@ export const hasCodeInUrl = (location: Location): boolean => {
   const hashParams = new URLSearchParams(location.hash.replace('#', '?'));
 
   return (
-    searchParams.has('code') ??
-    searchParams.has('id_token') ??
-    searchParams.has('session_state') ??
-    hashParams.has('code') ??
-    hashParams.has('id_token') ??
+    searchParams.has('code') ||
+    searchParams.has('id_token') ||
+    searchParams.has('session_state') ||
+    hashParams.has('code') ||
+    hashParams.has('id_token') ||
     hashParams.has('session_state')
   );
 };


### PR DESCRIPTION
Fixes issue #1074 so that onSignIn is called when signin in with hash params. Adds test to ensure callback works with hash routing.