### PR TITLE
feat!: fix handling popup sign in, add wrapper function for callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate-docs": "typedoc"
   },
   "dependencies": {
-    "oidc-client-ts": "^2.4.0"
+    "oidc-client-ts": "^3.2.0"
   },
   "devDependencies": {
     "@bjerk/eslint-config": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   oidc-client-ts:
-    specifier: ^2.4.0
-    version: 2.4.1
+    specifier: ^3.2.0
+    version: 3.2.0
 
 devDependencies:
   '@bjerk/eslint-config':
@@ -1340,10 +1340,6 @@ packages:
       which: 2.0.2
     dev: true
 
-  /crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-    dev: false
-
   /cssstyle@3.0.0:
     resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
     engines: {node: '>=14'}
@@ -2561,8 +2557,9 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /jwt-decode@3.1.2:
-    resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
+  /jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
     dev: false
 
   /keyv@4.5.4:
@@ -2846,12 +2843,11 @@ packages:
       es-object-atoms: 1.1.1
     dev: true
 
-  /oidc-client-ts@2.4.1:
-    resolution: {integrity: sha512-IxlGMsbkZPsHJGCliWT3LxjUcYzmiN21656n/Zt2jDncZlBFc//cd8WqFF0Lt681UT3AImM57E6d4N53ziTCYA==}
-    engines: {node: '>=12.13.0'}
+  /oidc-client-ts@3.2.0:
+    resolution: {integrity: sha512-wUvVcG3SXzZDKHxi/VGQGaTUk9qguMKfYh26Y1zOVrQsu1zp85JWx/SjZzKSXK5j3NA1RcasgMoaHe6gt1WNtw==}
+    engines: {node: '>=18'}
     dependencies:
-      crypto-js: 4.2.0
-      jwt-decode: 3.1.2
+      jwt-decode: 4.0.0
     dev: false
 
   /once@1.4.0:

--- a/src/__tests__/auth-context.test.tsx
+++ b/src/__tests__/auth-context.test.tsx
@@ -65,7 +65,6 @@ describe('AuthContext', () => {
   it('should open Popup when asked', async () => {
     const u = {
       getUser: vi.fn(),
-      signinPopupCallback: vi.fn(),
       signinPopup: vi.fn(),
       events,
     } as any;
@@ -81,8 +80,35 @@ describe('AuthContext', () => {
         </AuthProvider>,
       );
     });
-    expect(u.signinPopupCallback).toHaveBeenCalled();
     expect(u.signinPopup).toHaveBeenCalled();
+  });
+
+  it('should handle OIDC callback', async () => {
+    const u = {
+      getUser: vi.fn(),
+      signinCallback: vi.fn().mockResolvedValue({
+        access_token: 'token',
+      }),
+      events,
+    } as any;
+    const onSignIn = vi.fn();
+    
+    await act(async () => {
+      render(
+        <AuthProvider autoSignIn={false} onSignIn={onSignIn} userManager={u}>
+          <AuthContext.Consumer>
+            {value => {
+              value?.signInCallback();
+              return <p>Bjerk</p>;
+            }}
+          </AuthContext.Consumer>
+        </AuthProvider>,
+      );
+    });
+    expect(u.signinCallback).toHaveBeenCalled();
+    expect(onSignIn).toHaveBeenCalledWith({
+      access_token: 'token',
+    });
   });
 
   it('should not redirect when asked', async () => {

--- a/src/auth-context-interface.ts
+++ b/src/auth-context-interface.ts
@@ -156,6 +156,10 @@ export interface AuthContextProps {
    */
   signIn: (args?: SigninRedirectArgs) => Promise<void>;
   /**
+   * Alias for userManager.signInCallback
+   */
+  signInCallback: () => Promise<void>;
+  /**
    * Alias for userManager.signinPopup
    */
   signInPopup: () => Promise<void>;

--- a/src/auth-context.tsx
+++ b/src/auth-context.tsx
@@ -117,13 +117,19 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
       await onSignOut();
     }
   }, [onSignOut]);
+  const signInCallbackHooks = useCallback(async (url?: string): Promise<void> => {
+    const userFromCallback = await userManager.signinCallback(url) ?? null;
+    setUserData(userFromCallback);
+    if (onSignIn) {
+      await onSignIn(userFromCallback);
+    }
+  }, [userManager, onSignIn]);
   const signInPopupHooks = useCallback(async (): Promise<void> => {
     const userFromPopup = await userManager.signinPopup();
     setUserData(userFromPopup);
     if (onSignIn) {
       await onSignIn(userFromPopup);
     }
-    await userManager.signinPopupCallback();
   }, [userManager, onSignIn]);
 
   /**
@@ -214,6 +220,9 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
     return {
       signIn: async (args?: SigninRedirectArgs): Promise<void> => {
         await userManager.signinRedirect(args);
+      },
+      signInCallback: async (url?: string): Promise<void> => {
+        await signInCallbackHooks(url);
       },
       signInPopup: async (): Promise<void> => {
         await signInPopupHooks();


### PR DESCRIPTION
The wrapper `signInPopup()` calls `userManager.signinCallback()` on the main app window, right after popup promise is resolved. This is not correct, as `signinCallback()` should be only invoked on the redirect callback page or route. 

In popup flow after code is exchanged for token the popup window dispatches `postMessage()` to the opener in `oidc-client-ts` and is closed. However, when `signinCallback()` as is currently the popup window gets closed when token is retrieved and main window tries to perform OIDC callback, which fails and tries to send `postMessage()` to the `window.opener` which doesn't exist. This causes error `No window.opener.` from `oidc-client-ts` to be thrown.

This changes fixes the flow and additionally adds wrapper around `userManager.signinCallback()` to the `AuthContext`.