### PR TITLE
fix: silently renew expired access token on init instead of nulling userData

### DIFF
--- a/src/__tests__/auth-context.test.tsx
+++ b/src/__tests__/auth-context.test.tsx
@@ -92,7 +92,7 @@ describe('AuthContext', () => {
       events,
     } as any;
     const onSignIn = vi.fn();
-    
+
     await act(async () => {
       render(
         <AuthProvider autoSignIn={false} onSignIn={onSignIn} userManager={u}>
@@ -422,5 +422,38 @@ describe('AuthContext', () => {
     // then: the callback should be unregistered
     expect(u.events.removeSilentRenewError).toHaveBeenCalledTimes(1);
     expect(callbacks).toHaveLength(0);
+  });
+
+  it('should silently renew expired access token when user has a refresh token and auto login is disabled', async () => {
+    // given: a stored user whose access token has expired and
+    // user has a refresh token and a successful silent renewal
+    const u = {
+      getUser: async () => ({
+        access_token: 'old-token',
+        expired: true,
+        refresh_token: 'refresh-token',
+      }),
+      signinSilent: vi.fn(),
+      signinRedirect: vi.fn(),
+      events,
+    } as any;
+
+    let result: any;
+    await act(async () => {
+      result = render(
+        <AuthProvider userManager={u} autoSignIn={false}>
+          <AuthContext.Consumer>
+            {value =>
+              value?.userData && (
+                <span>Received: {value.userData.access_token}</span>
+              )
+            }
+          </AuthContext.Consumer>
+        </AuthProvider>,
+      );
+    });
+
+    // then: it renews silently, exposes the renewed user, and does NOT redirect
+    expect(u.signinSilent).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auth-context.tsx
+++ b/src/auth-context.tsx
@@ -117,13 +117,16 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
       await onSignOut();
     }
   }, [onSignOut]);
-  const signInCallbackHooks = useCallback(async (url?: string): Promise<void> => {
-    const userFromCallback = await userManager.signinCallback(url) ?? null;
-    setUserData(userFromCallback);
-    if (onSignIn) {
-      await onSignIn(userFromCallback);
-    }
-  }, [userManager, onSignIn]);
+  const signInCallbackHooks = useCallback(
+    async (url?: string): Promise<void> => {
+      const userFromCallback = (await userManager.signinCallback(url)) ?? null;
+      setUserData(userFromCallback);
+      if (onSignIn) {
+        await onSignIn(userFromCallback);
+      }
+    },
+    [userManager, onSignIn],
+  );
   const signInPopupHooks = useCallback(async (): Promise<void> => {
     const userFromPopup = await userManager.signinPopup();
     setUserData(userFromPopup);
@@ -171,6 +174,11 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
         else if (autoSignIn) {
           const state = onBeforeSignIn ? onBeforeSignIn() : undefined;
           await userManager.signinRedirect({ ...autoSignInArgs, state });
+        }
+        // If there is an existing user whose access token has expired
+        // but has a refresh token, attempt a silent renewal
+        else if (user && user.refresh_token) {
+          await userManager.signinSilent();
         }
       }
       // Otherwise if the user is already signed in, set the user data.


### PR DESCRIPTION
On initial render, `AuthProvider` now attempts a silent token renewal when it
finds a stored user whose access token has expired but user has a refresh token if autologin is disabled.

## Why

In the init effect, `userManager.getUser()` returns the stored user and the
expired branch is entered via `(!user || user.expired)`. Previously that branch
only had two outcomes for an expired user:

- `autoSignIn: true` → an immediate full-page `signinRedirect`, even though a
  valid refresh token was available and a silent renewal would have sufficed.
- `autoSignIn: false` → nothing happened, so `userData` was left `null` and the
  app treated the user as logged out despite a renewable session.

Neither path used the refresh token, so a user with an expired access token but
a valid refresh token was unnecessarily bounced to the provider (or shown as
signed out).

## Change

In the init effect, when there is an existing **expired** user and no auth code
in the URL and autologin is disabled, call `userManager.signinSilent()`.
